### PR TITLE
mraa_init: Run mraa_init prior to any other io init

### DIFF
--- a/source/aio.c
+++ b/source/aio.c
@@ -48,6 +48,10 @@ typedef struct adc_seq_table* adc_seq_table_ptr;
 mraa_aio_context
 mraa_aio_init(unsigned int pin)
 {
+    /* Make sure mraa is initialized */
+    if (mraa_init() != MRAA_SUCCESS)
+        return NULL;
+
     printf("Entering the mraa aio functionality\n");
     mraa_board_t* board = plat;
     if(board == NULL){

--- a/source/gpio.c
+++ b/source/gpio.c
@@ -67,6 +67,10 @@ static void gpio_internal_callback(struct device *port, struct gpio_callback *cb
 mraa_gpio_context
 mraa_gpio_init(int pin)
 {
+    /* Make sure mraa is initialized */
+    if (mraa_init() != MRAA_SUCCESS)
+        return NULL;
+
     mraa_board_t* board = plat;
     if (board == NULL) {
         printf("gpio: platform not initialised\n");

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -11,6 +11,10 @@ static struct _i2c tmp_i2c_dev;
 mraa_i2c_context
 mraa_i2c_init(int bus)
 {
+    /* Make sure mraa is initialized */
+    if (mraa_init() != MRAA_SUCCESS)
+        return NULL;
+
     mraa_board_t* board = plat;
     if (board == NULL) {
         // syslog(LOG_ERR, "i2c: Platform Not Initialised");

--- a/source/pwm.c
+++ b/source/pwm.c
@@ -57,6 +57,10 @@
 mraa_pwm_context
 mraa_pwm_init(int pin)
 {
+    /* Make sure mraa is initialized */
+    if (mraa_init() != MRAA_SUCCESS)
+        return NULL;
+
     mraa_board_t* board = plat;
     if (board == NULL) {
         return NULL;

--- a/source/uart.c
+++ b/source/uart.c
@@ -48,6 +48,10 @@
 mraa_uart_context
 mraa_uart_init(int uart)
 {
+    /* Make sure mraa is initialized */
+    if (mraa_init() != MRAA_SUCCESS)
+        return NULL;
+
     mraa_uart_context dev = (mraa_uart_context) malloc(sizeof(struct _uart));
     dev->zdev = device_get_binding(UART_DEVICE);
     dev->block = 1;


### PR DESCRIPTION
What's the best way to handle calling mraa_init for zephry?  This PR provides one solution but maybe there is a better way to do this?


Since the flow for calling mraa_init is different on zephyr
(compared to loading an .so), an explicit init was added to
at the beginning of each io init.

This enables upm c sensor examples to run on zephyr without
needing to call mraa_init.

Signed-off-by: Noel Eck <noel.eck@intel.com>