### PR TITLE
aio: Implemented mraa_aio_read_float and adc bit shifting

### DIFF
--- a/source/arduino_101_sss.c
+++ b/source/arduino_101_sss.c
@@ -148,6 +148,8 @@ mraa_board_t* mraa_intel_arduino_101_sss()
     b->pins[19].i2c.mux_total = 0;
     b->i2c_bus[0].sda = 18;
     b->i2c_bus[0].scl = 19;
+    b->adc_raw = 12;
+    b->adc_supported = 12;
 
 // sss will have a different configuration
 #if 0

--- a/source/mraa.c
+++ b/source/mraa.c
@@ -51,7 +51,6 @@ mraa_init()
 #elif defined(CONFIG_BOARD_QUARK_D2000_CRB)
     plat = mraa_intel_d2k_crb();
 #endif
-    printf("mraa_board_t = %d bytes\n", sizeof(mraa_board_t));
     return plat != NULL ? MRAA_SUCCESS : MRAA_ERROR_NO_RESOURCES;
 }
 
@@ -297,6 +296,30 @@ mraa_pin_mode_test(int pin, mraa_pinmodes_t mode)
             break;
     }
     return 0;
+}
+
+unsigned int
+mraa_adc_raw_bits()
+{
+    if (plat == NULL)
+        return 0;
+
+    if (plat->aio_count == 0)
+        return 0;
+
+    return plat->adc_raw;
+}
+
+unsigned int
+mraa_adc_supported_bits()
+{
+    if (plat == NULL)
+        return 0;
+
+    if (plat->aio_count == 0)
+        return 0;
+
+    return plat->adc_supported;
 }
 
 int


### PR DESCRIPTION
UPM C sensor drivers rely on mraa_aio_get/set_bit as well as
mraa_aio_read_float.  Added these methods and supporting code.

Removed some misc printf's which appear like they were there for
mraa debugging on zephyr.

Tested on zephyr 1.5.

Signed-off-by: Noel Eck noel.eck@intel.com
