### PR TITLE
Fix up some error checking in SPI

### DIFF
--- a/source/spi.c
+++ b/source/spi.c
@@ -191,6 +191,8 @@ mraa_spi_write_word(mraa_spi_context dev, uint16_t data)
     if (ret == 0) {
         return ret_data;
     }
+
+    return -1;
 }
 
 uint8_t*


### PR DESCRIPTION
1. spi.c: mraa_spi_init(): free resources and return NULL on error
   
   There is one place in spi_init() where an error occurs but NULL is
   not returned, causing an exception.
   
   In both error cases, allocated memory is not freed.
2. spi.c: mraa_spi_write: return proper -1 on error
3. spi.c: mraa_spi_write_word: return proper -1 on error
