### PR TITLE
pinmuxing: Enable board pinmux driver for mraa

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -20,6 +20,9 @@ config  MRAA
         bool
         prompt "Mraa Support"
         default n
+        select PINMUX
+        select PINMUX_DEV
+        select PINMUX_DEV_QMSI
         help
           This option enables the mraa lib
 


### PR DESCRIPTION
Enable the pinmux driver at the mraa level.

Signed-off-by: Noel Eck <noel.eck@intel.com>