### PR TITLE
GPIO: Pinmux Fixes

### DIFF
--- a/source/gpio.c
+++ b/source/gpio.c
@@ -97,7 +97,15 @@ mraa_gpio_init(int pin)
     } else if (pin == 5) {
         pinmux_pin_set(pinmux_dev, 64, PINMUX_FUNC_C);
         mraa_set_pininfo(board, 5, 15, "IO5", (mraa_pincapabilities_t){ 1, 1, 1, 0, 0, 0, 0, 0 });
-    } else {
+    } else if (pin == 10) {
+        pinmux_pin_set(pinmux_dev, 0, PINMUX_FUNC_A);
+    } else if (pin == 11) {
+        pinmux_pin_set(pinmux_dev, 3, PINMUX_FUNC_A);
+    } else if (pin == 12) {
+        pinmux_pin_set(pinmux_dev, 1, PINMUX_FUNC_A);
+    } else if (pin == 13) {
+        pinmux_pin_set(pinmux_dev, 2, PINMUX_FUNC_A);
+    } else if (pin == 6 || pin == 9 || (pin >= 14 && pin <= 19)) {
         printf("Pin %d not enabled/Can't be enabled\n", pin);
         return NULL;
     }


### PR DESCRIPTION
There was a bug in the pinmux enabling that was done for the
GPIO MRAA layer. This commit fixes those bugs and makes sure
other pins which were not being enabled are also enabled
from the x86 GPIO side.

Signed-off-by: Abhishek Malik <abhishek.malik@intel.com>