### PR TITLE
Readme corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,9 @@ Now build the sample.
 ```
 make BOARD=arduino_101 
 ```
+
+And upload it to the board by running:
+
+```bash
+dfu-util -R -a x86_app -D outdir/zephyr.bin
+```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supported APIs
 Protocols per Core: Arduino 101
 -------------------------------
 In general almost every protocol mentioned above is present on each core.
-However, that stops being the case when you look at it from the POV of whats
+However, that stops being the case when you look at it from the POV of what's
 present on the Arduino headers. The following table lists the protocols that
 are present on the **Quark core** and exposed via the headers:
 
@@ -39,17 +39,17 @@ Protocols available from the **ARC core**
 |   PWM    | Present                        |
 |   I2C    | Present                        |
 |   UART   | Not present                    |
-|   SPI    | Present(Only internally)       |
+|   SPI    | Present (Only internally)      |
 
 Pin Availability on Arduino 101 via ZMRAA
 -----------------------------------------
-The 101 there are atleast 69 pins that can be configured. ZMRAA tries to provide
+On 101 there are at least 69 pins that can be configured. ZMRAA tries to provide
 access to as many as possible. Most of the pins exposed on the headers of the
-Arduino 101 can be accessed via both the cores - Quark and ARC, but there are a
+Arduino 101 can be accessed via both cores - Quark and ARC, but there are a
 few pins and protocols that can be accessed from only one of the cores. To see
-which protocol is available on which core please check the concerning section.
+which protocol is available on which core please check the corresponding section.
 
-A look at the pins accessible via the **x86 core:**
+A look at the pins accessible via the **Quark core:**
 **GPIO** - D2-D5, D7, D8, D10-D13
 **PWM** - D3, D5, D6, D9
 **UART** - D0(RX), D1(TX)
@@ -58,7 +58,7 @@ A look at the pins accessible via the **x86 core:**
 Pins accessible via the **ARC core:**
 **GPIO** - D14-D19 (These are analog pins A0-A5 numbered 14-19)
 *ex: mraa_gpio_init(14); in this case pin A0 would be used as a digital pin*
-*    mraa_gpio_init(15); in this case its pin A1 and so on and so forth*
+*    mraa_gpio_init(15); in this case it's pin A1 and so on and so forth*
 
 **AIO** - A0-A5, D10-D13
 *you can number the digital pins as they are: mraa_aio_init(10)*
@@ -87,11 +87,11 @@ git am ext/lib/mraa/zmraa.patch
 
 Build GPIO Example
 ------------------
-Add mraa and gpio driver to your zephyr configuration and build sample.
-Device Drivers -> GPIO Drivers -> QMSI GPIO driver
-MRAA -> Mraa GPIO function support
-If you use a Quark D2k board then switch BOARD=arduino_101 for
-BOARD=quark_d2000_crb
+Add mraa and gpio driver to your Zephyr configuration and build sample.
+Select `Device Drivers -> GPIO Drivers -> QMSI GPIO driver` and
+`MRAA -> Mraa GPIO function support`
+If you use a Quark D2K board then switch `BOARD=arduino_101` for
+`BOARD=quark_d2000_crb`
 
 ```
 source $ZEPHYR_BASE/zephyr-env.sh
@@ -99,7 +99,7 @@ cd ext/lib/mraa/examples/shell
 make BOARD=arduino_101 menuconfig
 ```
 
-Now build the sample.
+Now build the sample:
 
 ```
 make BOARD=arduino_101 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Adding ZMRAA to Zephyr
 
 ```
 cd zephyr/ext/lib
-git clone git@github.com:intel-iot-devkit/zmraa.git mraa
+git clone https://github.com/intel-iot-devkit/zmraa.git mraa
 ```
 
 Then you need to apply [zmraa.patch](zmraa.patch) to add the configuration entries


### PR DESCRIPTION
Here's a set of main readme corrections I'd suggest to make.

As far ast the last patch and specifically the `menuconfig` part is concerned - it doesn't seem to be necessary at least as of Zephyr 1.5.0 I've tested this with. All those options are autoselected by means of `prj.conf`. But I need to test it out a bit more to propose removal.