### PR TITLE
[RFC] Let's turn mraa's Kconfig options into a dedicated submenu

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,4 @@
-# Kconfig - Cryptography primitive options for TinyCrypt
+# Kconfig - Configuration options for mraa library
 
 #
 # Copyright (c) 2015 Intel Corporation

--- a/Kconfig
+++ b/Kconfig
@@ -23,6 +23,7 @@ menuconfig  MRAA
         select PINMUX
         select PINMUX_DEV
         select PINMUX_DEV_QMSI
+        select NEWLIB_LIBC
         help
           This option enables the mraa lib
 

--- a/Kconfig
+++ b/Kconfig
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-config  MRAA
+menuconfig  MRAA
         bool
         prompt "Mraa Support"
         default n
@@ -26,10 +26,11 @@ config  MRAA
         help
           This option enables the mraa lib
 
+if MRAA
+
 config  MRAA_GPIO
         bool
-        prompt "Mraa GPIO function support"
-        select MRAA
+        prompt "GPIO function support"
         select GPIO
         default n
         help
@@ -37,8 +38,7 @@ config  MRAA_GPIO
 
 config  MRAA_AIO
         bool
-        prompt "Mraa AIO function support"
-        select MRAA
+        prompt "AIO function support"
         select AIO
         default n
         help
@@ -46,9 +46,8 @@ config  MRAA_AIO
 
 config  MRAA_I2C
         bool
-        prompt "Mraa I2C function support"
+        prompt "I2C function support"
         select I2C
-        select MRAA
         select MRAA_GPIO
         default n
         help
@@ -56,29 +55,28 @@ config  MRAA_I2C
 
 config  MRAA_PWM
         bool
-        prompt "Mraa PWM function support"
+        prompt "PWM function support"
         select PWM
-        select MRAA
         default n
         help
           This option enables support for MRAA PWM
 
 config  MRAA_UART
         bool
-        prompt "Mraa UART function support"
+        prompt "UART function support"
         select UART
-        select MRAA
         default n
         help
           This option enables support for MRAA UART
 
 config  MRAA_SPI
         bool
-        prompt "Mraa SPI function support"
+        prompt "SPI function support"
         select SPI
         select GPIO
-        select MRAA
-        select PINMUX
         default n
         help
           This option enables support for MRAA SPI
+
+endif
+


### PR DESCRIPTION
This one proposes a change I believe will make user experience with configuring mraa options better. Right now we present all options under External Sources as a plain list and that IMHO may mislead the user. My proposal is tu turn the `CONFIG_MRAA` into `menuconfig` and all other options would become sub-items - see screenshots below:

![mraa_submenu_2](https://cloud.githubusercontent.com/assets/6135723/20228161/50235934-a850-11e6-98b1-0e34f5f4d0a9.png)

![mraa_submenu_1](https://cloud.githubusercontent.com/assets/6135723/20228160/501d708c-a850-11e6-84ed-d718346240ef.png)

I had to remove `select MRAA` everywhere, as that caused options not to be shown in the menu (+we anyway select this in all our `prj*.conf` files).

Bundled are two smaller ones, a description correction and an addition of the `NEWLIB_LIBC`, we've discussed in PR #30 (@malikabhi05 mentioned other symbols as well, but let me start with just this one).

Let me know what you think on this.