### PR TITLE
zephyr-1.6: Update to enable mraa from arc on zephyr 1.6

### DIFF
--- a/source/mraa_internal_types.h
+++ b/source/mraa_internal_types.h
@@ -30,9 +30,6 @@
 #include <i2c.h>
 #include <pinmux.h>
 
-// Pack structures to save memory
-#pragma pack(push, 1)
-
 /**
  * A structure representing a gpio pin.
  */
@@ -278,4 +275,3 @@ typedef struct _board_t {
     /*@}*/
 } mraa_board_t;
 
-#pragma pack(pop)


### PR DESCRIPTION
    Removed byte packing for internal types.  This was causing a
    converged kernel running on the arc to fail.

Signed-off-by: Noel Eck <noel.eck@intel.com>