### PR TITLE
d2k: Removed duplicated header content, added ifdef

### DIFF
--- a/source/mraa_internal.h
+++ b/source/mraa_internal.h
@@ -32,59 +32,10 @@ extern "C" {
 #include "mraa_internal_types.h"
 
 extern mraa_board_t* plat;
+
+#if defined(CONFIG_BOARD_QUARK_D2000_CRB)
 static struct device* d2k_pinmux_dev;
-
-/**
- * Takes in pin information and sets up the multiplexors.
- *
- * @param meta
- * @return mraa result type indicating success of actions.
- */
-mraa_result_t mraa_setup_mux_mapped(mraa_pin_t meta);
-
-mraa_result_t mraa_set_pininfo(mraa_board_t* board, int mraa_pin, int zephyr_pin, char* name, mraa_pincapabilities_t caps);
-
-void mraa_set_board_config(mraa_board_t* board);
-
-
-#ifdef __cplusplus
-}
 #endif
-/*
- * Author: Thomas Ingleby <thomas.c.ingleby@intel.com>
- * Copyright (c) 2014 Intel Corporation.
- *
- * Permission is hereby granted, free of charge, to any person obtaining
- * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
- * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
- * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- */
-
-#pragma once
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "mraa/common.h"
-#include "mraa_internal_types.h"
-
-extern mraa_board_t* plat;
-static struct device* d2k_pinmux_dev;
 
 /**
  * Takes in pin information and sets up the multiplexors.


### PR DESCRIPTION
    * A portion of this file appears to be redundant - removed
    * Added #if defined(CONFIG_BOARD_QUARK_D2000_CRB) so struct
      is only available for D2000 (cleans up unused-variable)
      warning for other BOARDs

Signed-off-by: Noel Eck <noel.eck@intel.com>