### PR TITLE
uart: Added CONFIG for controlling uart

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -67,6 +67,7 @@ config  MRAA_UART
         bool
         prompt "Mraa UART function support"
         select UART
+        select UART_LINE_CTRL
         select MRAA
         default n
         help


### PR DESCRIPTION
    * If uart is enabled, pull in code to configure it
      with UART_LINE_CTRL

Signed-off-by: Noel Eck <noel.eck@intel.com>