### PR TITLE
D2000: Fix GPIO pins 0-5 not working

### DIFF
--- a/source/aio.c
+++ b/source/aio.c
@@ -90,6 +90,12 @@ mraa_aio_init(unsigned int pin)
         pinmux_pin_set(d2k_pinmux_dev, 16, PINMUX_FUNC_B);
         mraa_set_pininfo(board, 13, 16, "IO13", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 1, 0 });
     }
+
+    // The analog pins conflicted with the GPIO pins 0-5 prior to this change
+    // causing the GPIO pins 0-5 not to work on the d2000. 
+    if (pin >=0 && pin <= 5) {
+        pin = pin+14;
+    }
 #endif
 #if defined(CONFIG_BOARD_ARDUINO_101_SSS)
     if (pin == 0) {

--- a/source/intel_d2k_crb.c
+++ b/source/intel_d2k_crb.c
@@ -118,12 +118,12 @@ mraa_intel_d2k_crb()
     mraa_set_pininfo(b, 11, 17, "IO11", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 });
     mraa_set_pininfo(b, 12, 18, "IO12", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 });
     mraa_set_pininfo(b, 13, 16, "IO13", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 0, 0 });
-    mraa_set_pininfo(b, 0, 3, "A0  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 1, 0 });
-    mraa_set_pininfo(b, 1, 4, "A1  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 1, 0 });
-    mraa_set_pininfo(b, 2, 14, "A2  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 1, 0 });
-    mraa_set_pininfo(b, 3, 15, "A3  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 0, 1, 0 });
-    mraa_set_pininfo(b, 4, 7, "A4  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 1, 0 });
-    mraa_set_pininfo(b, 5, 6, "A5  ", (mraa_pincapabilities_t){ 1, 1, 0, 0, 0, 1, 1, 0 });
+    mraa_set_pininfo(b, 14, 3, "A0  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 });
+    mraa_set_pininfo(b, 15, 4, "A1  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 });
+    mraa_set_pininfo(b, 16, 14, "A2  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 });
+    mraa_set_pininfo(b, 17, 15, "A3  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 0, 1, 0 });
+    mraa_set_pininfo(b, 18, 7, "A4  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 1, 0 });
+    mraa_set_pininfo(b, 19, 6, "A5  ", (mraa_pincapabilities_t){ 1, 0, 0, 0, 0, 1, 1, 0 });
     b->def_i2c_bus = 0;
     b->i2c_bus[0].bus_id = 0;
     b->pins[18].i2c.mux_total = 0;


### PR DESCRIPTION
Fixed the gpio/aio pin number conflict for d2000. this was causing gpio pins 0-5 not to work.

Signed-off-by: Abhishek Malik <abhishek.malik@intel.com>